### PR TITLE
Allow getDriver() to return promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,15 +18,24 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
   self.start = function(url){
     log.info('starting '+self.name);
     var driver = args.getDriver();
-    self.driver_ = driver;
 
-    self.getSession_(function(session){
-      // TODO: caps_ might be a defer as well
-      self.setName(session.caps_.caps_);
-    });
+    var cb = function (driver) {
+      self.driver_ = driver;
 
-    log.info('sending driver to url '+url+'?id='+id);
-    driver.get(url+'?id='+id);
+      self.getSession_(function(session){
+        // TODO: caps_ might be a defer as well
+        self.setName(session.caps_.caps_);
+      });
+
+      log.info('sending driver to url '+url+'?id='+id);
+      driver.get(url+'?id='+id);
+    };
+
+    if (driver.then) {
+      driver.then(cb);
+    } else {
+      cb(driver);
+    }
   };
 
   self.kill = function(){


### PR DESCRIPTION
We'd like to change `getDriver()` so that it can optionally return a promise.  This would be useful for cases where asynchronous operations need to run before the driver can be returned.  

For example, if the driver fails to acquire a session, we'd like to retry:

```
{
    getDriver: function () {
        var done = webdriver.promise.defer();

        var driver = new webdriver.Builder()
            .forBrowser('chrome')
            .usingServer('http://localhost:4444/wd/hub')
            .build();

        driver.session_.then(function () {
            done.fulfill(driver);
        });

        setTimeout(function () {
            if (driver.session_.isPending()) {
                // cancel the session and retry
            }
        }, 5000);

        return done.promise;
    }
}
```
