### PR TITLE
Fix 2 issues with restart()

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
 
   log.info('SeleniumWebdriverBrowser (kid:'+id+') created');
 
-  self.start = function(url){
+  self._start = function(url){
     log.info('starting '+self.name);
     var driver = args.getDriver();
     self.driver_ = driver;
@@ -25,8 +25,8 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
       self.setName(session.caps_.caps_);
     });
 
-    log.info('sending driver to url '+url+'?id='+id);
-    driver.get(url+'?id='+id);
+    log.info('sending driver to url '+url);
+    driver.get(url);
   };
 
   self.kill = function(){
@@ -37,7 +37,6 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
     }
 
     var deferred = q.defer();
-
     killingPromise = deferred.promise;
 
     self.getSession_(function(session){
@@ -47,14 +46,15 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
         return deferred.reject();
       }
 
-      if(session.id_){
-        self.driver_ && self.driver_.quit();
-        deferred.resolve();
+      if(session.id_) {
+        self.driver_ && self.driver_.quit()
+          .then(function() {
+            deferred.resolve();
+          });
       }
     });
 
     return killingPromise;
-
   };
 
   self.forceKill = function() {

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
       if(session.id_) {
         self.driver_ && self.driver_.quit()
           .then(function() {
+            killingPromise = null;
             deferred.resolve();
           });
       }


### PR DESCRIPTION
Restart doesn't work for two reasons.

First, by overriding start instead of using the onStart listener, BaseLauncher doesn't remember the previousUrl and so tries to restart with url = undefined

Second, because kill() was not waiting for quit(), after fixing #1 there is a race condition where the driver is accessed after quit, resulting in an error message in the console.