### PR TITLE
Fix restart behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
 
   log.info('SeleniumWebdriverBrowser (kid:'+id+') created');
 
-  self.start = function(url){
+  self._start = function(url){
     log.info('starting '+self.name);
     var driver = args.getDriver();
     self.driver_ = driver;
@@ -25,8 +25,8 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
       self.setName(session.caps_.caps_);
     });
 
-    log.info('sending driver to url '+url+'?id='+id);
-    driver.get(url+'?id='+id);
+    log.info('sending driver to url '+url);
+    driver.get(url);
   };
 
   self.kill = function(){


### PR DESCRIPTION
Because start is overridden, subsequent calls to start don't have the previousUrl that would have been saved by BaseLauncher

This fixes it by implementing the onStart listener instead (and fixing the URLs)