### PR TITLE
Getting it to work with karma-1.7.0 and selenium-webdriver-3.7.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,12 +26,12 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
     });
 
     log.info('sending driver to url '+url);
-    driver.get(url).then(function(){
-		 self._done();
-	 }).catch( function(error){
-		 log.info('erroneous response from webdriver: ' + error);
-		 self._done(error);
-	 });
+    driver.get(url).catch( function(error) {
+      log.error('driver returned error: ' + error);
+      if(!killingPromise) {
+        self._done(error);
+      }
+    });
   };
 
   self.kill = function(){
@@ -54,13 +54,16 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
 
       if(session.id_ && self.driver_){
         self.driver_.quit().then(function(){
-				  deferred.resolve();
-				  self._done();
-			  }).catch( function(error){
-					log.info('error while quitting browser session: ' + error);
-				  self._done();
-			  });
-      }
+           self._done();
+           deferred.resolve();
+        }).catch( function(error){
+           self._done(error);
+           deferred.reject();
+        });
+      } else {
+        self._done('no webdriver session available');
+        deferred.reject();
+    }
     });
 
     return killingPromise;

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
     driver.get(url).catch( function(error) {
       log.error('driver returned error: ' + error);
       if(!killingPromise) {
+        self._retryLimit = -1 // don't retry
         self._done(error);
       }
     });
@@ -57,7 +58,8 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
            self._done();
            deferred.resolve();
         }).catch( function(error){
-           self._done(error);
+           self.info('error while quittin session: ' + error);
+           self._done();
            deferred.reject();
         });
       } else {

--- a/index.js
+++ b/index.js
@@ -1,123 +1,98 @@
-var q = require('q');
-//var webdriver = require('selenium-webdriver');
+var webdriver = require('selenium-webdriver');
 
-function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
-  baseBrowserDecorator(this);
-
-  var self = this;
-  var captured = false;
-  var log = logger.create('launcher.selenium-webdriver');
-  var browserName = args.browserName;
-  var killingPromise;
-
-  self.id = id;
-  self.setName(browserName);
-
-  log.info('SeleniumWebdriverBrowser (kid:'+id+') created');
-
-  self._start = function(url){
-    log.info('starting '+self.name);
-    var driver = args.getDriver();
-    self.driver_ = driver;
-
-    self.getSession_(function(session){
-      // TODO: caps_ might be a defer as well
-      self.setName(session.caps_.caps_);
-    });
-
-    log.info('sending driver to url '+url);
-    driver.get(url).catch( function(error) {
-      log.error('driver returned error: ' + error);
-      if(!killingPromise) {
-        self._retryLimit = -1 // don't retry
-        self._done(error);
-      }
-    });
-  };
-
-  self.kill = function(){
-
-    // Already killed, or being killed.
-    if (killingPromise) {
-      return killingPromise;
-    }
-
-    var deferred = q.defer();
-
-    killingPromise = deferred.promise;
-
-    self.getSession_(function(session){
-      log.info('requested to kill, session id is '+(session && session.id_));
-
-      if (!session) {
-        return deferred.reject();
-      }
-
-      if(session.id_ && self.driver_){
-        self.driver_.quit().then(function(){
-           self._done();
-           deferred.resolve();
-        }).catch( function(error){
-           self.info('error while quittin session: ' + error);
-           self._done();
-           deferred.reject();
-        });
-      } else {
-        self._done('no webdriver session available');
-        deferred.reject();
-    }
-    });
-
-    return killingPromise;
-
-  };
-
-  self.forceKill = function() {
-    self.kill();
-    return killingPromise;
-  };
-
+function browserNameFromCapabilities(caps) {
+	var browserName = caps.has(webdriver.Capability.BROWSER_NAME) ? caps.get(webdriver.Capability.BROWSER_NAME) : undefined;
+	if(caps.has(webdriver.Capability.VERSION)) {
+		browserName += (!!browserName ? ' ' : '') + caps.get(webdriver.Capability.VERSION);
+	}
+	if(caps.has(webdriver.Capability.PLATFORM)) {
+		browserName += (!!browserName ? ' ' : '') + '(' + caps.get(webdriver.Capability.PLATFORM) + ')';
+	}
+	return browserName;
 }
 
-SeleniumWebdriverBrowser.$inject = [ 'id', 'baseBrowserDecorator', 'args', 'logger' ];
+function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
+	baseBrowserDecorator(this);
 
-SeleniumWebdriverBrowser.prototype.setName = function(arg) {
-  // arg is either string and assumed to be `browserName` parameter
-  // or is object, being the session capabilities
-  var browserName;
-  if('string' === typeof arg){
-    browserName = arg;
-  }else if(arg && arg.version){
-    browserName = (arg.browserName || arg.device) + (arg.version ? ' ' + arg.version : '') + ' (' + arg.platform +  ')';
-  }
+	var self = this;
+	var browserName = args.browserName;
+	var getDriver = args.getDriver;
+	var log = logger.create('launcher.selenium-webdriver');
 
-  if(browserName){
-    this.name = browserName + ' via Selenium Webdriver';
-    console.log('changed name to '+this.name);
-  }
-};
+	self.id = id;
+	self.setName(browserName);
+	self.driver_ = null;
+	self._start = function() {}; // Preven ProcessLauncher from taking over.
 
-SeleniumWebdriverBrowser.prototype.getSession_ = function(cb) {
-  var driver = this.driver_;
+	self.on('start', function(url) {
+		log.info('starting ' + self.name);
 
-  if(!driver){
-    return cb(null);
-  }
+		var driver = self._driver || getDriver();
+		driver.getSession()
+			.then(function(session){
+				self._driver = driver;
+				self.setName(browserNameFromCapabilities(session.getCapabilities()));
 
-  if(driver.session_ && driver.session_.then){
-    driver.session_.then(cb);
-  }else{
-    cb(driver.session_);
+				log.info('sending driver to url ' + url);
+				self._driver.navigate().to(url)
+					.catch( function(error) {
+						log.error('driver returned error: ' + error);
+						if(self._driver !== null) {
+							self._handleStartError(error);
+						}
+					});
+			})
+			.catch(function(error){
+				log.error('failed to get session from webdriver: ' + error);
+				self._handleStartError(error);
+			});
+	});
+
+	self.on('kill', function(done) {
+		if(self._driver) {
+			var driver = self._driver;
+			self._driver = null;
+
+			driver.quit()
+				.then(self._allDone.bind(self, done))
+				.catch(function(error){
+					log.info('error while quittin session: ' + error);
+					self._allDone(done);
+				});
+		} else {
+			done();
+		}
+	});
+
+	log.info('SeleniumWebdriverBrowser (kid:'+id+') created');
+}
+
+SeleniumWebdriverBrowser.prototype._allDone = function(doneCallback) {
+	this._done();
+	doneCallback();
+}
+
+SeleniumWebdriverBrowser.prototype._handleStartError = function(error) {
+	this._retryLimit = -1 // dont't retry
+	this._done(error);
+}
+
+SeleniumWebdriverBrowser.prototype.setName = function(newBrowserName) {
+  if(!!newBrowserName) {
+    this.name = newBrowserName + ' via Selenium Webdriver';
+    console.log('changed name to ' + this.name);
   }
 };
 
 SeleniumWebdriverBrowser.prototype.isCaptured = function(){
-  return !!this.driver_;
+  return !!this._driver;
 };
 
 SeleniumWebdriverBrowser.prototype.toString = function() {
   return this.name || 'Unnamed SeleniumWebdriverBrowser';
 };
+
+SeleniumWebdriverBrowser.$inject = ['id', 'baseBrowserDecorator', 'args', 'logger'];
 
 // PUBLISH DI MODULE
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,11 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
     });
 
     log.info('sending driver to url '+url);
-    driver.get(url);
+    driver.get(url).then(function(){
+		 self._done();
+	 }).catch( function(error){
+		 self._done(error);
+	 });
   };
 
   self.kill = function(){
@@ -47,9 +51,14 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
         return deferred.reject();
       }
 
-      if(session.id_){
-        self.driver_ && self.driver_.quit();
-        deferred.resolve();
+      if(session.id_ && self.driver_){
+        self.driver_.quit().then(function(){
+				  deferred.resolve();
+				  self._done();
+			  }).catch( function(error){
+					log.info('error while quitting browser session: ' + error);
+				  self._done();
+			  });
       }
     });
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ function SeleniumWebdriverBrowser(id, baseBrowserDecorator, args, logger) {
     driver.get(url).then(function(){
 		 self._done();
 	 }).catch( function(error){
+		 log.info('erroneous response from webdriver: ' + error);
 		 self._done(error);
 	 });
   };

--- a/package.json
+++ b/package.json
@@ -21,14 +21,10 @@
   },
   "peerDependencies": {
     "karma": ">=0.9",
-    "selenium-webdriver": "^2.44.0"
+    "selenium-webdriver": "^3.6.0"
   },
   "license": "MIT",
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-bump": "~0.0.7",
-    "grunt-npm": "~0.0.2",
-    "grunt-auto-release": "~0.0.2"
   },
   "author": "PixnBits <github@pixnbits.org>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -17,10 +17,9 @@
     "browser-stack"
   ],
   "dependencies": {
-    "q": "~0.9.6"
   },
   "peerDependencies": {
-    "karma": ">=0.9",
+    "karma": "^1.7.0",
     "selenium-webdriver": "^3.6.0"
   },
   "license": "MIT",


### PR DESCRIPTION
The initial issue, was that karma was not quitting after having run all the browsers.
It seemed to be waiting for a self._done call from this launcher.

After having fixed the done and _done calls to satisfy karma, I tried to refactor the launcher to avoid overriding base methods. My goal was to use the provided events 'start' and 'kill' to perform the requested actions.
This was quite a change to the initial code but also removed the dependency to q for promises.

I am not quite sure about backwards compatibility to earlier versions of karma as I my main intend was to get it to work with our setup of karma and selenium.

Up until now I successfully testet the implementation using the following components:
- karma-1.7.0
- selenium-webdriver-3.7.0
- seleniumHub-3.7.0 using the following browser drivers
    * IEDriverServer-3.7.0
    * geckodriver-0.19.1
    * ChromeDriver-2.33

There is only one issue with IEDriverServer, which errors after quitting but having executed all the tests successfully. I suspect it does not handle the drivers quit call like the other drivers but I did not want to integrate browser specific code into the pull request.

I know the pull request is quite a change (sorry for that) but it now allows us to run our tests fully automated on our selenium based infrastructure.